### PR TITLE
Wizard Form - Added Root component array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-autoform-utils",
-  "version": "1.0.3",
+  "version": "1.0.4-experimental",
   "description": "Common javascript files to all the redux-autoform related projects",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/factory/ComponentFactory.js
+++ b/src/factory/ComponentFactory.js
@@ -23,6 +23,12 @@ export default class ComponentFactory {
 
         // The id of the default component for groups
         this.defaultGroupComponentId = null;
+
+        // This this a list of Root components
+        this.rootComponentsById = { };
+
+        this.currentRoot = null;
+
     }
 
     /**
@@ -190,5 +196,21 @@ export default class ComponentFactory {
             throw new Error(`Could not resolve the component for the group`);
 
         return React.createElement(componentType, groupComponentProps);
+    }
+
+
+    // Allows to register a new Root component
+    registerRootComponent(id, component) {
+        this.rootComponentsById[id] = component;
+    }
+
+    // Allows to define the id of the current Root component that should be used
+    setCurrentRoot(id) {
+        this.currentRoot = id;
+    }
+
+    // Return the selected Root component in AutoformInternal
+    getRoot() {
+        return this.rootComponentsById[this.currentRoot];
     }
 }


### PR DESCRIPTION
Helloo!, this is related to PRs redux-autoform/redux-autoform#68 and redux-autoform/redux-autoform-bootstrap-ui#32.
The idea is to have and array of Root component that are registered in each UI factory, also each UI factory should set the default Root. Using an array can give us the possibility to change the Root component dinamically
